### PR TITLE
fix dappeteer to work with the latest active metamask version (1.8.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import puppeteer from 'puppeteer';
 import dappeteer from '@chainsafe/dappeteer';
 
 async function main() {
-  const browser = await dappeteer.launch(puppeteer, { metamaskVersion: 'v10.1.1' });
+  const browser = await dappeteer.launch(puppeteer, { metamaskVersion: 'v10.8.1' });
   const metamask = await dappeteer.setupMetamask(browser);
 
   // you can change the network if you want

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,7 @@ For additional information read root [readme](../README.md)
   - [unlock](#unlock)
   - [switchNetwork](#switchNetwork)
   - [addNetwork](#addNetwork)
+  - [addToken](#addToken)
   - [confirmTransaction](#confirmTransaction)
   - [sign](#sign)
   - [approve](#approve)
@@ -38,6 +39,7 @@ returns an instance of `browser`, same as `puppeteer.launch`, but it also instal
 interface MetamaskOptions {
   seed?: string;
   password?: string;
+  showTestNets?: boolean;
 }
 ```
 
@@ -81,6 +83,10 @@ interface AddNetwork {
 }
 ```
 it adds a custom network to MetaMask.
+
+<a name="addToken"></a>
+## `metamask.addToken(tokenAddress: string): Promise<void>`
+it adds a custom token to MetaMask.  
 
 <a name="confirmTransaction"></a>
 ## `metamask.confirmTransaction(options?: TransactionOptions): Promise<void>`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/dappeteer",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "E2E testing for dApps using Puppeteer + MetaMask",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { isNewerVersion } from './utils';
 export { getMetamask };
 
 export type LaunchOptions = Parameters<typeof puppeteer['launch']>[0] & {
-  metamaskVersion: 'v10.1.1' | 'latest' | string;
+  metamaskVersion: 'v10.8.1' | 'latest' | string;
   metamaskLocation?: Path;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export type LaunchOptions = Parameters<typeof puppeteer['launch']>[0] & {
 export type MetamaskOptions = {
   seed?: string;
   password?: string;
+  showTestNets?: boolean;
 };
 
 export type AddNetwork = {
@@ -46,7 +47,7 @@ export type TransactionOptions = {
   gasLimit?: number;
 };
 
-export const RECOMMENDED_METAMASK_VERSION = 'v10.1.1';
+export const RECOMMENDED_METAMASK_VERSION = 'v10.8.1';
 
 /**
  * Launch Puppeteer chromium instance with MetaMask plugin installed
@@ -96,7 +97,19 @@ export async function launch(puppeteerLib: typeof puppeteer, options: LaunchOpti
 /**
  * Setup MetaMask with base account
  * */
-export async function setupMetamask(browser: puppeteer.Browser, options: MetamaskOptions = {}): Promise<Dappeteer> {
+const defaultMetamaskOptions: MetamaskOptions = {
+  showTestNets: true,
+};
+
+export async function setupMetamask(
+  browser: puppeteer.Browser,
+  options: MetamaskOptions = defaultMetamaskOptions,
+): Promise<Dappeteer> {
+  // set default values of not provided values (but required)
+  for (const key of Object.keys(defaultMetamaskOptions)) {
+    if (options[key] === undefined) options[key] = defaultMetamaskOptions[key];
+  }
+
   const page = await closeHomeScreen(browser);
   await confirmWelcomeScreen(page);
 
@@ -107,6 +120,8 @@ export async function setupMetamask(browser: puppeteer.Browser, options: Metamas
   );
 
   await closeNotificationPage(browser);
+
+  await showTestNets(page);
 
   return getMetamask(page);
 }
@@ -152,6 +167,23 @@ async function closeNotificationPage(browser: puppeteer.Browser): Promise<void> 
       }
     }
   });
+}
+
+async function showTestNets(metamaskPage: puppeteer.Page): Promise<void> {
+  const networkSwitcher = await metamaskPage.waitForSelector('.network-display');
+  await networkSwitcher.click();
+  await metamaskPage.waitForSelector('li.dropdown-menu-item');
+
+  const showHideButton = await metamaskPage.waitForSelector('.network-dropdown-content--link');
+  await showHideButton.click();
+
+  const option = await metamaskPage.waitForSelector(
+    '.settings-page__body > div:nth-child(7) > div:nth-child(2) > div > div > div:nth-child(1)',
+  );
+  await option.click();
+
+  const header = await metamaskPage.waitForSelector('.app-header__logo-container');
+  await header.click();
 }
 
 async function confirmWelcomeScreen(metamaskPage: puppeteer.Page): Promise<void> {

--- a/src/metamask/addNetwork.ts
+++ b/src/metamask/addNetwork.ts
@@ -14,43 +14,41 @@ export const addNetwork = (page: Page, version?: string) => async ({
   const networkSwitcher = await page.waitForSelector('.network-display');
   await networkSwitcher.click();
   await page.waitForSelector('li.dropdown-menu-item');
-  const networkIndex = await page.evaluate((network) => {
-    const elements = document.querySelectorAll('li.dropdown-menu-item');
-    for (let i = 0; i < elements.length; i++) {
-      const element = elements[i];
-      if ((element as HTMLLIElement).innerText.toLowerCase().includes(network.toLowerCase())) {
-        return i;
-      }
-    }
-    return elements.length - 1;
-  }, 'Custom RPC');
-  const networkButton = (await page.$$('li.dropdown-menu-item'))[networkIndex];
+
+  const networkButton = await page.waitForSelector('.menu-droppo > button');
   await networkButton.click();
 
-  const networkNameInput = await page.waitForSelector('input#network-name');
+  const networkNameInput = await page.waitForSelector(
+    '.networks-tab__add-network-form-body > div:nth-child(1) > label > input',
+  );
   await networkNameInput.type(networkName);
 
-  const rpcInput = await page.waitForSelector('input#rpc-url');
+  const rpcInput = await page.waitForSelector(
+    '.networks-tab__add-network-form-body > div:nth-child(2) > label > input',
+  );
   await rpcInput.type(rpc);
 
-  const chainIdInput = await page.waitForSelector('input#chainId');
+  const chainIdInput = await page.waitForSelector(
+    '.networks-tab__add-network-form-body > div:nth-child(3) > label > input',
+  );
   await chainIdInput.type(String(chainId));
 
   if (symbol) {
-    const symbolInput = await page.waitForSelector('input#network-ticker');
+    const symbolInput = await page.waitForSelector(
+      '.networks-tab__add-network-form-body > div:nth-child(4) > label > input',
+    );
     await symbolInput.type(symbol);
   }
   if (explorer) {
-    const explorerInput = await page.waitForSelector('input#block-explorer-url');
+    const explorerInput = await page.waitForSelector(
+      '.networks-tab__add-network-form-body > div:nth-child(5) > label > input',
+    );
     await explorerInput.type(explorer);
   }
 
-  const saveButton = await page.waitForSelector('.network-form__footer > button.button.btn-secondary');
+  const saveButton = await page.waitForSelector(
+    '.networks-tab__add-network-form-footer > button.button.btn--rounded.btn-primary',
+  );
   await saveButton.click();
-
-  await page.waitForSelector('button.button.btn-danger');
-  const logo = await page.waitForSelector('.app-header__logo-container.app-header__logo-container--clickable');
-  await logo.click();
-
   await page.waitForXPath(`//*[text() = '${networkName}']`);
 };

--- a/src/metamask/addToken.ts
+++ b/src/metamask/addToken.ts
@@ -3,11 +3,13 @@ import { Page } from 'puppeteer';
 export const addToken = (page: Page) => async (tokenAddress: string): Promise<void> => {
   await page.bringToFront();
 
-  const addTokenButton = await page.waitForSelector('.add-token-button > button');
+  const addTokenButton = await page.waitForSelector(
+    '.box.import-token-link.box--flex-direction-row.box--text-align-center > a',
+  );
   await addTokenButton.click();
 
   const addressInput = await page.waitForSelector('#custom-address');
-  addressInput.type(tokenAddress);
+  await addressInput.type(tokenAddress);
 
   await page.waitForTimeout(4000);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Short description of work done**
<!-- e.g. Refactored auth logic as part of the transition to OAuth -->

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have run linter locally
- [x] I have run unit and integration tests locally
  - [x] Update configuration the newest version (readme and const)
- [x] Rebased to master branch / merged master

### Changes
<!-- Please describe all changes made to codebase. -->
- _EXAMPLE - Removed basic auth from the controller_

<!-- ### Example -->
<!-- You can add screenshots or videos to show changed behaviour -->

### Issues
<!-- Use github keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #55
Closes #56
Closes #58 
Closes #59 
Closes #60 
Closes #78 