### PR TITLE
Adding an option to hide the seed phrase

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -40,6 +40,7 @@ interface MetamaskOptions {
   seed?: string;
   password?: string;
   showTestNets?: boolean;
+  hideSeed?: boolean;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/dappeteer",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "E2E testing for dApps using Puppeteer + MetaMask",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/dappeteer",
-  "version": "2.4.1",
+  "version": "2.4.0",
   "description": "E2E testing for dApps using Puppeteer + MetaMask",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,7 +193,12 @@ async function confirmWelcomeScreen(metamaskPage: puppeteer.Page): Promise<void>
   await continueButton.click();
 }
 
-async function importAccount(metamaskPage: puppeteer.Page, seed: string, password: string, hideSeed: boolean): Promise<void> {
+async function importAccount(
+  metamaskPage: puppeteer.Page,
+  seed: string,
+  password: string,
+  hideSeed: boolean,
+): Promise<void> {
   const importLink = await metamaskPage.waitForSelector('.first-time-flow button');
   await importLink.click();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type MetamaskOptions = {
   seed?: string;
   password?: string;
   showTestNets?: boolean;
+  hideSeed?: boolean;
 };
 
 export type AddNetwork = {
@@ -117,6 +118,7 @@ export async function setupMetamask(
     page,
     options.seed || 'already turtle birth enroll since owner keep patch skirt drift any dinner',
     options.password || 'password1234',
+    options.hideSeed,
   );
 
   await closeNotificationPage(browser);
@@ -191,18 +193,24 @@ async function confirmWelcomeScreen(metamaskPage: puppeteer.Page): Promise<void>
   await continueButton.click();
 }
 
-async function importAccount(metamaskPage: puppeteer.Page, seed: string, password: string): Promise<void> {
+async function importAccount(metamaskPage: puppeteer.Page, seed: string, password: string, hideSeed: boolean): Promise<void> {
   const importLink = await metamaskPage.waitForSelector('.first-time-flow button');
   await importLink.click();
 
   const metricsOptOut = await metamaskPage.waitForSelector('.metametrics-opt-in button.btn-primary');
   await metricsOptOut.click();
 
-  const showSeedPhraseInput = await metamaskPage.waitForSelector('#ftf-chk1-label');
-  await showSeedPhraseInput.click();
+  if (hideSeed) {
+    const seedPhraseInput = await metamaskPage.waitForSelector('.first-time-flow__seedphrase input[type=password]');
+    await seedPhraseInput.click();
+    await seedPhraseInput.type(seed);
+  } else {
+    const showSeedPhraseInput = await metamaskPage.waitForSelector('#ftf-chk1-label');
+    await showSeedPhraseInput.click();
 
-  const seedPhraseInput = await metamaskPage.waitForSelector('.first-time-flow textarea');
-  await seedPhraseInput.type(seed);
+    const seedPhraseInput = await metamaskPage.waitForSelector('.first-time-flow textarea');
+    await seedPhraseInput.type(seed);
+  }
 
   const passwordInput = await metamaskPage.waitForSelector('#password');
   await passwordInput.type(password);


### PR DESCRIPTION
### What Changed:

I wanted an option to have the seed phrase hidden upon setup.  I added a new boolean to allow this.  The default remains as clicking the showSeedPhraseInput to make the seed visible while setting up metamask, so this is not a breaking change.

Discussion #83 

Closes #85 