### PR TITLE
feat: custom automation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export {
   DappeteerLaunchOptions,
   MetaMaskOptions,
   TransactionOptions,
+  CustomAutomation,
 } from "./types";
 export { DappeteerBrowser } from "./browser";
 export { DappeteerPage } from "./page";

--- a/src/setup/launch.ts
+++ b/src/setup/launch.ts
@@ -71,6 +71,13 @@ export async function launch(
 
   if (options.automation) {
     switch (options.automation) {
+      case "custom":
+        console.warn("Custom automation in use. Proceed at own risk.");
+        if (!options.customAutomation) {
+          fs.rmSync(userDataDir, { recursive: true, force: true });
+          throw new Error("Missing customBootstrap method in options");
+        }
+        return options.customAutomation(metamaskPath, userDataDir, options);
       case "playwright":
         return await launchPlaywright(metamaskPath, userDataDir, options);
       case "puppeteer":

--- a/src/setup/launch.ts
+++ b/src/setup/launch.ts
@@ -77,7 +77,11 @@ export async function launch(
           fs.rmSync(userDataDir, { recursive: true, force: true });
           throw new Error("Missing customBootstrap method in options");
         }
-        return options.customAutomation(metamaskPath, userDataDir, options);
+        return await options.customAutomation(
+          metamaskPath,
+          userDataDir,
+          options
+        );
       case "playwright":
         return await launchPlaywright(metamaskPath, userDataDir, options);
       case "puppeteer":

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export type DappeteerLaunchOptions = {
   key?: string;
 };
 
-type CustomAutomation = (
+export type CustomAutomation = (
   metamaskPath: string,
   userDataDir: string,
   options: DappeteerLaunchOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import { Path } from "./setup/utils/metaMaskDownloader";
 import { InstallStep } from "./snap/install";
 import { NotificationItem, NotificationList } from "./snap/types";
 import NotificationsEmitter from "./snap/NotificationsEmitter";
-import { RECOMMENDED_METAMASK_VERSION } from "./index";
+import { DappeteerBrowser, RECOMMENDED_METAMASK_VERSION } from "./index";
 
 export type DappeteerLaunchOptions = {
   metaMaskVersion?:
@@ -19,13 +19,20 @@ export type DappeteerLaunchOptions = {
   //install flask (canary) version of metamask.
   metaMaskFlask?: boolean;
   //fallbacks to installed dependency and prefers playwright if both are installed
-  automation?: "puppeteer" | "playwright";
+  automation?: "puppeteer" | "playwright" | "custom";
+  customAutomation?: CustomAutomation;
   headless?: boolean; // default true
   puppeteerOptions?: Parameters<typeof puppeteerLaunch>[0];
   playwrightOptions?: PlaywrightLaunchOptions;
   userDataDir?: string;
   key?: string;
 };
+
+type CustomAutomation = (
+  metamaskPath: string,
+  userDataDir: string,
+  options: DappeteerLaunchOptions
+) => Promise<DappeteerBrowser>;
 
 declare global {
   interface Window {


### PR DESCRIPTION
Due to the request from the community for "plugins", this is one experimentation approach to it. It will not be covered by the test and the wound not provides support, so use it at your own risk.

<hr />

### Usages Example
It is recommended to use typescript.

```typescript
import dappeteer from '@chainsafe/dappeteer';
import puppeteer from 'puppeteer-extra';
import StealthPlugin from 'puppeteer-extra-plugin-stealth';
import {DPuppeteerBrowser} from "@chainsafe/dappeteer/dist/puppeteer";

async function main() {
  const { metaMask, browser } = await dappeteer.bootstrap({
    automation: "custom",
    customAutomation: async (metamaskPath, userDataDir, options) => {
      puppeteer.use(StealthPlugin());
      const browser = puppeteer.launch({
        userDataDir,
        args: [
           `--disable-extensions-except=${metamaskPath}`,
           `--load-extension=${metamaskPath}`,
        ],
      });
      return DPuppeteerBrowser(browser, userDataDir, options.metaMaskFlask);
    },
  });

  // create a new page and visit your dapp
  const dappPage = await browser.newPage();
  await dappPage.goto('http://my-dapp.com');

  // you can change the network if you want
  await metaMask.switchNetwork('goerli');

  // do something in your dapp that prompts MetaMask to add a Token
  const addTokenButton = await dappPage.$('#add-token');
  await addTokenButton.click();
  // instruct MetaMask to accept this request
  await metaMask.acceptAddToken();

  // do something that prompts MetaMask to confirm a transaction
  const payButton = await dappPage.$('#pay-with-eth');
  await payButton.click();

  // 🏌
  await metaMask.confirmTransaction();
}
main();
```