### PR TITLE
fix: use params in InvokeSnap method

### DIFF
--- a/src/snap/invokeSnap.ts
+++ b/src/snap/invokeSnap.ts
@@ -20,6 +20,7 @@ export async function invokeSnap<
           params: {
             request: {
               method: opts.method,
+              params: opts.params,
             },
             snapId: opts.snapId,
           },


### PR DESCRIPTION
**Short description of work done**
Just added a line in the invokeSnap method to use params.

### PR Checklist

- [X] I have run linter locally
- [X] I have run unit and integration tests locally
  - [X] Update configuration the newest version (readme and const)
- [X] Rebased to master branch / merged master

### Changes
Now invokeSnap rpc calls use the params of the method.

<!-- [REQUIRED] -->
Closes #333 
