### PR TITLE
fix: add evaluate element click for closeWhatsNewModal

### DIFF
--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -194,11 +194,11 @@ export const clickOnLittleDownArrowIfNeeded = async (
 };
 
 export const evaluateElementClick = async (
-    page: DappeteerPage,
-    selector: string,
+  page: DappeteerPage,
+  selector: string
 ): Promise<void> => {
-    /* For some reason popup deletes close button and then create new one (react stuff)
-     * hacky solution can be found here => https://github.com/puppeteer/puppeteer/issues/3496 */
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    await page.$eval(selector, (node) => node.click());
+  /* For some reason popup deletes close button and then create new one (react stuff)
+  * hacky solution can be found here => https://github.com/puppeteer/puppeteer/issues/3496 */
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  await page.$eval(selector, (node) => node.click());
 };

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -192,3 +192,13 @@ export const clickOnLittleDownArrowIfNeeded = async (
     await littleArrowDown.click();
   }
 };
+
+export const evaluateElementClick = async (
+    page: DappeteerPage,
+    selector: string,
+): Promise<void> => {
+    /* For some reason popup deletes close button and then create new one (react stuff)
+     * hacky solution can be found here => https://github.com/puppeteer/puppeteer/issues/3496 */
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await page.$eval(selector, (node) => node.click());
+};

--- a/src/helpers/actions.ts
+++ b/src/helpers/actions.ts
@@ -198,7 +198,7 @@ export const evaluateElementClick = async (
   selector: string
 ): Promise<void> => {
   /* For some reason popup deletes close button and then create new one (react stuff)
-  * hacky solution can be found here => https://github.com/puppeteer/puppeteer/issues/3496 */
+   * hacky solution can be found here => https://github.com/puppeteer/puppeteer/issues/3496 */
   await new Promise((resolve) => setTimeout(resolve, 1000));
   await page.$eval(selector, (node) => node.click());
 };

--- a/src/setup/setupActions.ts
+++ b/src/setup/setupActions.ts
@@ -8,6 +8,7 @@ import {
   openSettingsScreen,
   typeOnInputField,
   waitForOverlay,
+  evaluateElementClick
 } from "../helpers";
 import { DappeteerPage } from "../page";
 import { MetaMaskOptions } from "../types";
@@ -90,14 +91,11 @@ export async function importAccount(
 }
 
 export const closePopup = async (page: DappeteerPage): Promise<void> => {
-  /* For some reason popup deletes close button and then create new one (react stuff)
-   * hacky solution can be found here => https://github.com/puppeteer/puppeteer/issues/3496 */
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  await page.$eval(".popover-header__button", (node) => node.click());
+    await evaluateElementClick(page, ".popover-header__button");
 };
 
 export const closeWhatsNewModal = async (
-  page: DappeteerPage
+    page: DappeteerPage
 ): Promise<void> => {
-  await clickOnButton(page, "popover-close");
+    await evaluateElementClick(page, '[data-testid="popover-close"]');
 };

--- a/src/setup/setupActions.ts
+++ b/src/setup/setupActions.ts
@@ -8,7 +8,7 @@ import {
   openSettingsScreen,
   typeOnInputField,
   waitForOverlay,
-  evaluateElementClick
+  evaluateElementClick,
 } from "../helpers";
 import { DappeteerPage } from "../page";
 import { MetaMaskOptions } from "../types";
@@ -91,11 +91,11 @@ export async function importAccount(
 }
 
 export const closePopup = async (page: DappeteerPage): Promise<void> => {
-    await evaluateElementClick(page, ".popover-header__button");
+  await evaluateElementClick(page, ".popover-header__button");
 };
 
 export const closeWhatsNewModal = async (
-    page: DappeteerPage
+  page: DappeteerPage
 ): Promise<void> => {
-    await evaluateElementClick(page, '[data-testid="popover-close"]');
+  await evaluateElementClick(page, '[data-testid="popover-close"]');
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide all required information
-->

**Short description of work done**
Fixing 'Node is Detached from Document' Error in Puppeteer/Dappeteer Code: Refactoring closeWhatsNewModal Logic

### PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] I have run linter locally
- [ ] I have run unit and integration tests locally
- [ ] Update configuration the newest version (readme and const)
- [ ] Rebased to master branch / merged master

### Changes
<!-- Please describe all changes made to codebase. -->
I encountered an intermittent 'Node is detached from document' error while using the closeWhatsNewModal method. This issue occurred sporadically due to the dynamic nature of the application, where the close button was deleted and recreated.

To address this problem, I implemented a solution similar to what was used in the closePopup method. Specifically, I introduced a new method called evaluateElementClick that contains the necessary logic. This method includes a 1-second delay to handle scenarios where elements are dynamically recreated. Both closePopup and closeWhatsNewModal methods now use evaluateElementClick.

(Added new pull request because last wasn't working with cla)
<!-- ### Example -->
<!-- You can add screenshots or videos to show changed behaviour -->
Error solved:
![image](https://github.com/ChainSafe/dappeteer/assets/54986853/e6cceb08-1911-4c27-b55b-34c34d5c881d)


### Issues
<!-- Use github keyword to close issues that are related to this PR -->

<!-- [REQUIRED] -->
Closes #
